### PR TITLE
fix: logfiles contains %s strings, not actual messages

### DIFF
--- a/ia_downloader.py
+++ b/ia_downloader.py
@@ -88,7 +88,7 @@ class TermEscapeCodeFilter(logging.Filter):
 
     def filter(self, record):
         escape_re = re.compile(r"\x1b\[[0-9;]*m")
-        record.msg_without_colours = re.sub(escape_re, "", str(record.msg))
+        record.msg_without_colours = re.sub(escape_re, "", str(record.getMessage()))
         return True
 
 


### PR DESCRIPTION
fix: after recent code refactor, logfiles contains %s instead of arguments

record.getMessage() must be called to render the message from record.msg
and arguments.
